### PR TITLE
feat(cli): add declarative agent workflow with full CLI support.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,8 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
+ "console",
+ "convert_case",
  "derivative",
  "duckduckgo",
  "futures",
@@ -227,8 +229,10 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tokio",
  "tokio-rustls 0.26.2",
+ "toml_edit",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -582,6 +586,15 @@ dependencies = [
  "once_cell",
  "unicode-width",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -3600,6 +3613,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.9.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "servo_arc"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4058,6 +4084,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54449f7f7569ce6f57cda7812361961c0f6a77f720802537b5618585b4a7ff4c"
+dependencies = [
+ "indexmap 2.9.0",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5c1c469eda89749d2230d8156a5969a69ffe0d6d01200581cdc6110674d293e"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b679217f2848de74cabd3e8fc5e6d66f40b7da40f8e1954d92054d9010690fd5"
+
+[[package]]
 name = "tonic"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4276,6 +4339,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4286,6 +4355,12 @@ name = "unit-prefix"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -4945,6 +5020,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ members = [
     "autogpt",
 ]
 exclude = [
-    "examples"
+    "examples",
+    "target"
 ]
 
 [workspace.dependencies]

--- a/autogpt/Cargo.toml
+++ b/autogpt/Cargo.toml
@@ -60,6 +60,10 @@ rustls-pemfile = { version = "2.2.0", features = ["std"], optional = true }
 anthropic-ai-sdk = { version = "0.2.24", optional = true }
 x-ai = { version = "0.0.1", optional = true }
 indicatif = { version = "0.17.11", optional = true }
+console = { version = "0.16.0", optional = true }
+convert_case = { version = "0.8.0", optional = true }
+serde_yaml = { version = "0.9.34", optional = true }
+toml_edit = { version = "0.23.0", optional = true }
 
 [features]
 default = []
@@ -77,7 +81,11 @@ cli = [
     "clap",
     "prost",
     "rustls",
+    "console",
     "indicatif",
+    "toml_edit",
+    "serde_yaml",
+    "convert_case",
     "tokio-rustls",
     "rustls-pemfile",
     "tracing-appender",

--- a/autogpt/src/cli/autogpt.rs
+++ b/autogpt/src/cli/autogpt.rs
@@ -1,4 +1,15 @@
 #[cfg(feature = "cli")]
+pub mod ast;
+#[cfg(feature = "cli")]
+pub mod commands;
+#[cfg(feature = "cli")]
+pub mod generator;
+#[cfg(feature = "cli")]
+pub mod parser;
+#[cfg(feature = "cli")]
+pub mod utils;
+
+#[cfg(feature = "cli")]
 use clap::{Parser, Subcommand};
 
 #[cfg(feature = "cli")]
@@ -70,8 +81,52 @@ pub struct Cli {
 
 /// Represents available subcommands for the autogpt CLI.
 #[cfg(feature = "cli")]
-#[derive(Subcommand, Debug)]
+#[derive(Subcommand, Debug, PartialEq)]
 pub enum Commands {
+    /// Scaffold a new agent project from scratch
+    #[command(
+        name = "new",
+        about = "Create a new agent project",
+        long_about = "Scaffold a new AutoGPT-compatible agent project with YAML config and Cargo setup."
+    )]
+    New {
+        /// Name of the agent project (used as directory name)
+        #[arg()]
+        name: String,
+    },
+
+    /// Build the Rust code generated from agent.yaml
+    #[command(
+        name = "build",
+        about = "Compile generated agent source code",
+        long_about = "Parses `agent.yaml`, generates Rust code in `src/main.rs` (or a custom location), and compiles the project using Cargo."
+    )]
+    Build {
+        /// Optional output path for generated Rust file (default: src/main.rs)
+        #[arg(short, long, value_name = "FILE")]
+        out: Option<String>,
+    },
+
+    /// Run the compiled agent executable
+    #[command(
+        name = "run",
+        about = "Run the compiled agent",
+        long_about = "Executes the agent with the specified AI feature. This assumes the project is built successfully."
+    )]
+    Run {
+        /// AI provider feature to activate (e.g. gem, oai, cld, etc.)
+        #[arg(short, long, default_value = "gem", value_name = "FEATURE")]
+        feature: String,
+    },
+
+    /// Perform a dry-run to validate the YAML file
+    #[command(
+        name = "test",
+        about = "Validate agent.yaml file",
+        long_about = "Checks the structure and required fields in `agent.yaml` without generating or compiling code."
+    )]
+    Test,
+
     #[clap(
         name = "man",
         about = "ManagerGPT: Generate complete project requirements, specs, and task plans."

--- a/autogpt/src/cli/autogpt/ast.rs
+++ b/autogpt/src/cli/autogpt/ast.rs
@@ -1,0 +1,11 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AgentConfig {
+    pub name: String,
+    pub ai_provider: String,
+    pub model: String,
+    pub position: String,
+    pub role: String,
+    pub prompt: String,
+}

--- a/autogpt/src/cli/autogpt/commands.rs
+++ b/autogpt/src/cli/autogpt/commands.rs
@@ -1,0 +1,4 @@
+pub mod build;
+pub mod new;
+pub mod run;
+pub mod test;

--- a/autogpt/src/cli/autogpt/commands/build.rs
+++ b/autogpt/src/cli/autogpt/commands/build.rs
@@ -1,0 +1,31 @@
+use crate::cli::autogpt::{generator::generate_code, parser::parse_yaml, utils::*};
+use anyhow::Result;
+use std::path::Path;
+use std::process::Stdio;
+
+pub fn handle_build(out: Option<String>) -> Result<()> {
+    let config = parse_yaml("agent.yaml")?;
+    let output_path = out
+        .as_deref()
+        .map(Path::new)
+        .unwrap_or(Path::new("src/main.rs"));
+
+    spinner("Generating Rust code", || {
+        generate_code(&config, output_path)
+    })?;
+
+    success("✅ Code generation complete");
+
+    spinner("Compiling project", || {
+        std::process::Command::new("cargo")
+            .arg("build")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .status()
+            .map(|_| ())
+            .map_err(|e| e.into())
+    })?;
+
+    success("✅ Build complete");
+    Ok(())
+}

--- a/autogpt/src/cli/autogpt/commands/new.rs
+++ b/autogpt/src/cli/autogpt/commands/new.rs
@@ -1,0 +1,87 @@
+use crate::cli::autogpt::utils::*;
+use anyhow::{Context, Result, bail};
+use std::{fs, path::Path, process::Command};
+use toml_edit::{Array, DocumentMut, InlineTable, Item, Table, Value};
+
+pub fn handle_new(name: &str) -> Result<()> {
+    let path = Path::new(name);
+    if path.exists() {
+        bail!("❌ Directory '{}' already exists", name);
+    }
+
+    spinner("📦 Scaffolding project", || {
+        Command::new("cargo")
+            .arg("new")
+            .arg("--bin")
+            .arg(name)
+            .status()
+            .context("Failed to create cargo project")?;
+
+        fs::write(path.join("agent.yaml"), DEFAULT_YAML.trim_start())?;
+        fs::write(
+            path.join("README.md"),
+            format!("# {name}\n\nCreated with `agentc new`."),
+        )?;
+
+        let cargo_toml_path = path.join("Cargo.toml");
+        let mut doc: DocumentMut = fs::read_to_string(&cargo_toml_path)?
+            .parse()
+            .context("Failed to parse Cargo.toml")?;
+
+        let deps = doc["dependencies"].or_insert(Item::Table(Table::new()));
+        let deps = deps.as_table_mut().unwrap();
+
+        let mut tokio_table = InlineTable::new();
+        tokio_table.insert("version", Value::from("1.45.1"));
+        tokio_table.insert(
+            "features",
+            Value::Array({
+                let mut a = Array::default();
+                a.push("full");
+                a
+            }),
+        );
+        deps.insert("tokio", Item::Value(Value::InlineTable(tokio_table)));
+
+        let mut autogpt_table = InlineTable::new();
+        autogpt_table.insert("version", Value::from("0.1.9"));
+        autogpt_table.insert("default-features", Value::from(false));
+        autogpt_table.insert(
+            "features",
+            Value::Array({
+                let mut a = Array::default();
+                a.push("gem");
+                a
+            }),
+        );
+        deps.insert("autogpt", Item::Value(Value::InlineTable(autogpt_table)));
+
+        let features = doc["features"].or_insert(Item::Table(Table::new()));
+        let f_table = features.as_table_mut().unwrap();
+
+        let mut gem_array = Array::default();
+        gem_array.push("autogpt/gem");
+        f_table.insert("gem", Item::Value(Value::Array(gem_array)));
+
+        for feat in ["net", "mem", "oai", "cld", "xai"] {
+            f_table.insert(feat, Item::Value(Value::Array(Array::default())));
+        }
+
+        fs::write(&cargo_toml_path, doc.to_string())?;
+
+        Ok(())
+    })?;
+
+    success(&format!("✅ Project created at ./{name}"));
+    Ok(())
+}
+
+const DEFAULT_YAML: &str = r#"
+name: agent_name
+ai_provider: gemini
+model: gemini-2.0-flash
+position: Backend Engineer
+role: user
+prompt: |
+  Describe a scalable microservice architecture.
+"#;

--- a/autogpt/src/cli/autogpt/commands/run.rs
+++ b/autogpt/src/cli/autogpt/commands/run.rs
@@ -1,0 +1,17 @@
+use crate::cli::autogpt::utils::*;
+use anyhow::Result;
+use std::process::Command;
+
+pub fn handle_run(feature: String) -> Result<()> {
+    spinner("Running application", || {
+        Command::new("cargo")
+            .arg("run")
+            .arg("--features")
+            .arg(feature)
+            .status()
+            .map(|_| ())
+            .map_err(|e| e.into())
+    })?;
+
+    Ok(())
+}

--- a/autogpt/src/cli/autogpt/commands/test.rs
+++ b/autogpt/src/cli/autogpt/commands/test.rs
@@ -1,0 +1,14 @@
+use crate::cli::autogpt::parser::parse_yaml;
+use crate::cli::autogpt::utils::*;
+use anyhow::Result;
+
+pub fn handle_test() -> Result<()> {
+    spinner("Validating YAML file", || {
+        let config = parse_yaml("agent.yaml")?;
+        println!("🔍 Agent(s) parsed:\n{config:#?}");
+        Ok(())
+    })?;
+
+    success("✅ YAML is valid");
+    Ok(())
+}

--- a/autogpt/src/cli/autogpt/generator.rs
+++ b/autogpt/src/cli/autogpt/generator.rs
@@ -1,0 +1,73 @@
+use crate::cli::autogpt::ast::AgentConfig;
+use anyhow::Result;
+use convert_case::{Case, Casing};
+use std::fs;
+use std::path::Path;
+
+pub fn generate_code(config: &AgentConfig, out: &Path) -> Result<()> {
+    let struct_name = config.name.to_case(Case::UpperCamel);
+    let code = format!(
+        r#"#![allow(unused)]
+
+use autogpt::prelude::*;
+use std::borrow::Cow;
+
+#[derive(Debug, Default, Auto)]
+pub struct {name} {{
+    objective: Cow<'static, str>,
+    position: Cow<'static, str>,
+    status: Status,
+    agent: AgentGPT,
+    client: ClientType,
+    memory: Vec<Communication>,
+}}
+
+#[async_trait]
+impl Executor for {name} {{
+    async fn execute<'a>(
+        &'a mut self,
+        tasks: &'a mut Task,
+        execute: bool,
+        browse: bool,
+        max_tries: u64,
+    ) -> Result<()> {{
+        let prompt = self.agent.objective().clone();
+        let response = self.send_request(prompt.as_ref()).await?;
+
+        self.agent.add_communication(Communication {{
+            role: "{role}".into(),
+            content: response.clone().into(),
+        }});
+
+        println!("{{}}", response);
+        Ok(())
+    }}
+}}
+
+#[tokio::main]
+async fn main() {{
+    let agent = {name}::new(
+        "{prompt}".into(),
+        "{position}".into()
+    );
+
+    let autogpt = AutoGPT::default()
+        .with(agents![agent])
+        .build()
+        .expect("Build failed");
+
+    match autogpt.run().await {{
+        Ok(response) => println!("{{}}", response),
+        Err(err) => eprintln!("Agent error: {{:?}}", err),
+    }}
+}}
+"#,
+        name = struct_name,
+        role = config.role,
+        prompt = config.prompt,
+        position = config.position,
+    );
+
+    fs::write(out, code)?;
+    Ok(())
+}

--- a/autogpt/src/cli/autogpt/parser.rs
+++ b/autogpt/src/cli/autogpt/parser.rs
@@ -1,0 +1,21 @@
+use crate::cli::autogpt::ast::AgentConfig;
+use anyhow::{Context, Result, bail};
+use std::fs;
+
+pub fn parse_yaml(path: &str) -> Result<AgentConfig> {
+    let content = fs::read_to_string(path).context("Failed to read YAML file")?;
+    let config: AgentConfig = serde_yaml::from_str(&content).context("Invalid YAML structure")?;
+
+    validate_config(&config)?;
+    Ok(config)
+}
+
+fn validate_config(config: &AgentConfig) -> Result<()> {
+    if config.name.is_empty() {
+        bail!("Agent name is required");
+    }
+    if config.prompt.trim().is_empty() {
+        bail!("Prompt cannot be empty");
+    }
+    Ok(())
+}

--- a/autogpt/src/cli/autogpt/utils.rs
+++ b/autogpt/src/cli/autogpt/utils.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+use console::Style;
+use indicatif::{ProgressBar, ProgressStyle};
+use std::time::Duration;
+
+pub fn success(msg: &str) {
+    let green = Style::new().green().bold();
+    println!("{}", green.apply_to(msg));
+}
+
+pub fn spinner<F: FnOnce() -> Result<()>>(message: &str, func: F) -> Result<()> {
+    let pb = ProgressBar::new_spinner();
+    pb.set_style(
+        ProgressStyle::default_spinner()
+            .tick_strings(&["◑", "◒", "◐", "◓", "◑", "✅"])
+            .template("{spinner} {msg}")?,
+    );
+    pb.enable_steady_tick(Duration::from_millis(120));
+    pb.set_message(message.to_string());
+
+    let result = func();
+
+    pb.finish_with_message("Done");
+    result
+}


### PR DESCRIPTION
- Introduced support for declaratively defining agents via `agent.yaml`
- Added `autogpt new <name>` command to scaffold new agent projects.
- Added `autogpt build [--out=...]` to parse YAML and generate `main.rs`, then compile.
- Added `autogpt run [--feature=gem]` to execute compiled agent with feature flag.
- Added `autogpt test` to validate `agent.yaml` structure.

- [X] I have tested these changes locally.

Related to #36 


https://github.com/user-attachments/assets/a5d59b40-9b6b-4e8a-bf99-eadbb053d7a1

