### PR TITLE
feat(cli): implement auto-update mechanism && auto detect agent env vars feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,7 @@ dependencies = [
  "colored",
  "console",
  "convert_case",
+ "crates_io_api",
  "derivative",
  "duckduckgo",
  "futures",
@@ -227,6 +228,7 @@ dependencies = [
  "reqwest 0.11.27",
  "rustls 0.23.28",
  "rustls-pemfile 2.2.0",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -452,6 +454,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -685,6 +688,23 @@ dependencies = [
  "core-graphics",
  "foreign-types 0.5.0",
  "libc",
+]
+
+[[package]]
+name = "crates_io_api"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200ad30d24892baf2168f2df366939264d02f2fa0be0914f8e2da4bd3407c58c"
+dependencies = [
+ "chrono",
+ "futures",
+ "reqwest 0.12.22",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_path_to_error",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -3597,6 +3617,16 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
  "serde",
 ]
 

--- a/autogpt/Cargo.toml
+++ b/autogpt/Cargo.toml
@@ -64,6 +64,8 @@ console = { version = "0.16.0", optional = true }
 convert_case = { version = "0.8.0", optional = true }
 serde_yaml = { version = "0.9.34", optional = true }
 toml_edit = { version = "0.23.0", optional = true }
+crates_io_api = { version = "0.11.0", optional = true }
+semver = { version = "1.0.26", optional = true }
 
 [features]
 default = []
@@ -81,12 +83,14 @@ cli = [
     "clap",
     "prost",
     "rustls",
+    "semver",
     "console",
     "indicatif",
     "toml_edit",
     "serde_yaml",
     "convert_case",
     "tokio-rustls",
+    "crates_io_api",
     "rustls-pemfile",
     "tracing-appender",
     "tracing-subscriber",

--- a/autogpt/src/cli/autogpt.rs
+++ b/autogpt/src/cli/autogpt.rs
@@ -115,8 +115,8 @@ pub enum Commands {
     )]
     Run {
         /// AI provider feature to activate (e.g. gem, oai, cld, etc.)
-        #[arg(short, long, default_value = "gem", value_name = "FEATURE")]
-        feature: String,
+        #[arg(short, long, value_name = "FEATURE")]
+        feature: Option<String>,
     },
 
     /// Perform a dry-run to validate the YAML file

--- a/autogpt/src/cli/autogpt/commands/build.rs
+++ b/autogpt/src/cli/autogpt/commands/build.rs
@@ -16,7 +16,7 @@ pub fn handle_build(out: Option<String>) -> Result<()> {
 
     success("✅ Code generation complete");
 
-    spinner("Compiling project", || {
+    spinner("Compiling agent", || {
         std::process::Command::new("cargo")
             .arg("build")
             .stdout(Stdio::piped())

--- a/autogpt/src/cli/autogpt/commands/new.rs
+++ b/autogpt/src/cli/autogpt/commands/new.rs
@@ -1,7 +1,22 @@
+use crate::cli::autogpt::ast::AgentConfig;
 use crate::cli::autogpt::utils::*;
 use anyhow::{Context, Result, bail};
-use std::{fs, path::Path, process::Command};
+use std::env;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::{fs, process::Command};
 use toml_edit::{Array, DocumentMut, InlineTable, Item, Table, Value};
+
+const DEFAULT_YAML: &str = r#"
+name: agent_name
+ai_provider: gemini
+model: gemini-2.0-flash
+position: Backend Engineer
+role: user
+prompt: |
+  Describe a scalable microservice architecture.
+"#;
 
 pub fn handle_new(name: &str) -> Result<()> {
     let path = Path::new(name);
@@ -20,7 +35,7 @@ pub fn handle_new(name: &str) -> Result<()> {
         fs::write(path.join("agent.yaml"), DEFAULT_YAML.trim_start())?;
         fs::write(
             path.join("README.md"),
-            format!("# {name}\n\nCreated with `agentc new`."),
+            format!("# {name}\n\nCreated with `autogpt new`."),
         )?;
 
         let cargo_toml_path = path.join("Cargo.toml");
@@ -44,7 +59,7 @@ pub fn handle_new(name: &str) -> Result<()> {
         deps.insert("tokio", Item::Value(Value::InlineTable(tokio_table)));
 
         let mut autogpt_table = InlineTable::new();
-        autogpt_table.insert("version", Value::from("0.1.9"));
+        autogpt_table.insert("version", Value::from("0.1.11"));
         autogpt_table.insert("default-features", Value::from(false));
         autogpt_table.insert(
             "features",
@@ -72,16 +87,81 @@ pub fn handle_new(name: &str) -> Result<()> {
         Ok(())
     })?;
 
+    set_env(path)?;
+
     success(&format!("✅ Project created at ./{name}"));
     Ok(())
 }
 
-const DEFAULT_YAML: &str = r#"
-name: agent_name
-ai_provider: gemini
-model: gemini-2.0-flash
-position: Backend Engineer
-role: user
-prompt: |
-  Describe a scalable microservice architecture.
-"#;
+fn set_env(project_path: &Path) -> Result<()> {
+    let yaml_path = project_path.join("agent.yaml");
+    let yaml_content = std::fs::read_to_string(&yaml_path).context("Failed to read agent.yaml")?;
+
+    let config: AgentConfig =
+        serde_yaml::from_str(&yaml_content).context("Failed to parse agent.yaml")?;
+
+    if cfg!(windows) {
+        set_env_win("AI_PROVIDER", &config.ai_provider)?;
+        if config.ai_provider == "gemini" {
+            set_env_win("GEMINI_MODEL", &config.model)?;
+        }
+        success("✅ Environment variables set using 'setx'.\nRestart your terminal to apply them.");
+    } else {
+        let profile_path = find_shell()?;
+        append(&profile_path, "AI_PROVIDER", &config.ai_provider)?;
+        if config.ai_provider == "gemini" {
+            append(&profile_path, "GEMINI_MODEL", &config.model)?;
+        }
+        success(&format!(
+            "✅ Environment variables added to '{}'.\nRun `source {}` or restart your terminal to apply them.",
+            profile_path.display(),
+            profile_path.display()
+        ));
+    }
+
+    Ok(())
+}
+
+fn set_env_win(key: &str, value: &str) -> Result<()> {
+    let status = Command::new("setx")
+        .arg(key)
+        .arg(value)
+        .status()
+        .context("Failed to execute 'setx'")?;
+
+    if !status.success() {
+        bail!(
+            "setx failed with exit code: {}",
+            status.code().unwrap_or(-1)
+        );
+    }
+
+    Ok(())
+}
+
+fn append(profile_path: &Path, key: &str, value: &str) -> Result<()> {
+    let export_line = format!("export {key}={value}\n");
+    let existing = std::fs::read_to_string(profile_path).unwrap_or_default();
+
+    if !existing.contains(export_line.trim()) {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(profile_path)?;
+        file.write_all(export_line.as_bytes())?;
+    }
+
+    Ok(())
+}
+
+fn find_shell() -> Result<PathBuf> {
+    let home = env::var("HOME").context("HOME environment variable not set")?;
+    let candidates = [".bashrc", ".zshrc", ".profile"];
+    for filename in &candidates {
+        let path = Path::new(&home).join(filename);
+        if path.exists() {
+            return Ok(path);
+        }
+    }
+    Ok(Path::new(&home).join(".bashrc"))
+}

--- a/autogpt/src/cli/autogpt/commands/run.rs
+++ b/autogpt/src/cli/autogpt/commands/run.rs
@@ -1,13 +1,30 @@
 use crate::cli::autogpt::utils::*;
-use anyhow::Result;
+use anyhow::{Result, bail};
+use std::env;
 use std::process::Command;
 
-pub fn handle_run(feature: String) -> Result<()> {
-    spinner("Running application", || {
+pub fn handle_run(mut feature: String) -> Result<()> {
+    if feature.trim().is_empty() || feature.trim().eq_ignore_ascii_case("none") {
+        let ai_provider = env::var("AI_PROVIDER")
+            .map(|v| v.to_lowercase())
+            .unwrap_or_else(|_| "unknown".into());
+
+        feature = match ai_provider.as_str() {
+            "gemini" => "gem".to_string(),
+            "openai" => "oai".to_string(),
+            "anthropic" => "cld".to_string(),
+            "xai" => "xai".to_string(),
+            _ => bail!(
+                "❌ Unknown or missing AI_PROVIDER environment variable.\nPlease set AI_PROVIDER to one of: gemini, openai, anthropic, xai."
+            ),
+        };
+    }
+
+    spinner("🚀 Running application", || {
         Command::new("cargo")
             .arg("run")
             .arg("--features")
-            .arg(feature)
+            .arg(&feature)
             .status()
             .map(|_| ())
             .map_err(|e| e.into())


### PR DESCRIPTION
- [X] I have tested these changes locally.

Inspired by `zsh`, starting from version `0.1.11`, running `autogpt` will prompt you to update the CLI if a new upstream version is available.

![update](https://github.com/user-attachments/assets/59fc7cee-6748-4105-84e3-530ec66423d2)
