### PR TITLE
feat(core): configurable AutoGPT, Gemini imagen support, fix long term mem fetch.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auto-derive"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "async-trait",
  "proc-macro2",
@@ -206,6 +206,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "auto-derive",
+ "bytes",
  "chrono",
  "clap",
  "colored",
@@ -223,7 +224,7 @@ dependencies = [
  "nylas",
  "openai_dive",
  "pinecone-sdk",
- "reqwest 0.11.27",
+ "reqwest 0.12.22",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ webbrowser = "1.0.1"
 colored = "2.1.0"
 futures = "0.3.31"
 async-trait = "0.1.88"
-auto-derive = { version = "0.0.6", path = "./auto-derive" }
+auto-derive = { version = "0.0.7", path = "./auto-derive" }
 iac-rs = { version = "0.0.6", path = "./iac-rs" }
 auto-net = "0.0.1"
 chrono = "0.4.41"

--- a/auto-derive/Cargo.toml
+++ b/auto-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auto-derive"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2024"
 description = "autogpt macro crate."
 license = "MIT"

--- a/auto-derive/src/lib.rs
+++ b/auto-derive/src/lib.rs
@@ -255,6 +255,97 @@ pub fn derive_agent(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                     }
                 }
             }
+
+            async fn imagen(&mut self, request: &str) -> Result<Vec<u8>> {
+                match &mut self.client {
+                    #[cfg(feature = "gem")]
+                    ClientType::Gemini(gem_client) => {
+                        gem_client.set_model(Model::FlashExpImage);
+
+                        let input = Message::User {
+                            content: Content::Text(request.into()),
+                            name: None,
+                        };
+
+                        let params = ImageGenBuilder::default()
+                            .model(Model::FlashExpImage)
+                            .input(input)
+                            .build()?;
+
+                        let image_bytes = gem_client.images().generate(params).await;
+                        Ok(image_bytes.unwrap_or_default())
+                    }
+
+                    #[cfg(feature = "oai")]
+                    ClientType::OpenAI(oai_client) => {
+                        // TODO: Implement this
+                        Ok(Default::default())
+                    }
+
+                    #[cfg(feature = "cld")]
+                    ClientType::Anthropic(client) => {
+                        // TODO: Implement this
+                        Ok(Default::default())
+                    }
+
+                    #[cfg(feature = "xai")]
+                    ClientType::Xai(xai_client) => {
+                        // TODO: Implement this
+                        Ok(Default::default())
+                    }
+
+
+                    #[allow(unreachable_patterns)]
+                    _ => {
+                        return Err(anyhow!(
+                            "No valid AI client configured. Enable `gem`, `oai`, `cld`, or `xai` feature."
+                        ));
+                    }
+                }
+            }
+
+            async fn stream(&mut self, request: &str) -> Result<ReqResponse> {
+                match &mut self.client {
+                    #[cfg(feature = "gem")]
+                    ClientType::Gemini(gem_client) => {
+                        let parameters = StreamBuilder::default()
+                            .model(Model::Flash20)
+                            .input(Message::User {
+                                content: Content::Text(request.into()),
+                                name: None,
+                            })
+                            .build()?;
+
+                        Ok(ReqResponse(Some(gem_client.stream().generate(parameters).await?)))
+                    }
+
+                    #[cfg(feature = "oai")]
+                    ClientType::OpenAI(oai_client) => {
+                        // TODO: Implement this
+                        Ok(Default::default())
+                    }
+
+                    #[cfg(feature = "cld")]
+                    ClientType::Anthropic(client) => {
+                        // TODO: Implement this
+                        Ok(Default::default())
+                    }
+
+                    #[cfg(feature = "xai")]
+                    ClientType::Xai(xai_client) => {
+                        // TODO: Implement this
+                        Ok(Default::default())
+                    }
+
+
+                    #[allow(unreachable_patterns)]
+                    _ => {
+                        return Err(anyhow!(
+                            "No valid AI client configured. Enable `gem`, `oai`, `cld`, or `xai` feature."
+                        ));
+                    }
+                }
+            }
         }
     };
 

--- a/autogpt/Cargo.toml
+++ b/autogpt/Cargo.toml
@@ -41,7 +41,7 @@ iac-rs = { workspace = true, optional = true }
 
 uuid = { version = "1.16.0", features = ["v4"] }
 tokio = { version = "1.37.0", default-features = false, features = ["full"] }
-reqwest = { version = "0.11.27", features = ["json"] }
+reqwest = { version = "0.12.22", features = ["json"] }
 serde = { version = "1.0.197", features = ["derive"] }
 gems = { version = "0.1.3", optional = true }
 getimg = { version = "0.0.1", optional = true }
@@ -61,6 +61,7 @@ serde_yaml = { version = "0.9.34", optional = true }
 toml_edit = { version = "0.23.0", optional = true }
 crates_io_api = { version = "0.11.0", optional = true }
 semver = { version = "1.0.26", optional = true }
+bytes = "1.10.1"
 
 [features]
 default = []

--- a/autogpt/src/agents.rs
+++ b/autogpt/src/agents.rs
@@ -9,7 +9,6 @@ pub mod architect;
 #[cfg(feature = "gpt")]
 pub mod backend;
 #[cfg(feature = "gpt")]
-#[cfg(feature = "img")]
 pub mod designer;
 #[cfg(feature = "gpt")]
 pub mod frontend;

--- a/autogpt/src/agents/architect.rs
+++ b/autogpt/src/agents/architect.rs
@@ -53,8 +53,8 @@ use crate::traits::functions::{AsyncFunctions, Executor, Functions};
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use colored::*;
-use duckduckgo::browser::Browser;
-use duckduckgo::user_agents::get;
+// use duckduckgo::browser::Browser;
+// use duckduckgo::user_agents::get;
 use reqwest::Client as ReqClient;
 use std::borrow::Cow;
 use std::env::var;
@@ -84,9 +84,15 @@ use anthropic_ai_sdk::types::message::{
 #[cfg(feature = "gem")]
 use gems::{
     chat::ChatBuilder,
+    imagen::ImageGenBuilder,
     messages::{Content, Message},
+    models::Model,
+    stream::StreamBuilder,
     traits::CTrait,
 };
+
+#[cfg(any(feature = "oai", feature = "gem", feature = "cld", feature = "xai"))]
+use crate::traits::functions::ReqResponse;
 
 #[cfg(feature = "xai")]
 use x_ai::{
@@ -198,7 +204,8 @@ impl ArchitectGPT {
             }
         }
 
-        let agent: AgentGPT = AgentGPT::new_borrowed(objective, position);
+        let mut agent: AgentGPT = AgentGPT::new_borrowed(objective, position);
+        agent.id = agent.position().to_string().into();
 
         let client = ClientType::from_env();
 
@@ -753,8 +760,9 @@ impl ArchitectGPT {
     }
 
     async fn search_solution_and_regenerate(&mut self, tasks: &mut Task) -> Result<String> {
-        let browser = Browser::new(self.req_client.clone());
-        let user_agent = get("firefox").unwrap();
+        // TODO: remove `req_client` arg in duckduckgo
+        // let browser = Browser::new(self.req_client.clone());
+        // let user_agent = get("firefox").unwrap();
 
         let query = format!("Python error handling for: {}", tasks.description);
         info!(
@@ -764,9 +772,10 @@ impl ArchitectGPT {
                 .bold()
         );
 
-        let results = browser
-            .lite_search(&query, "wt-wt", Some(3), user_agent)
-            .await?;
+        // let results = browser
+        //     .lite_search(&query, "wt-wt", Some(3), user_agent)
+        //     .await?;
+        let results = vec!["".to_string()];
 
         for result in &results {
             info!(
@@ -774,7 +783,8 @@ impl ArchitectGPT {
                 format!(
                     "[*] {:?}: DuckDuckGo result: {}",
                     self.agent.position(),
-                    result.title
+                    // result.title
+                    result
                 )
                 .bright_cyan()
             );

--- a/autogpt/src/agents/backend.rs
+++ b/autogpt/src/agents/backend.rs
@@ -91,9 +91,15 @@ use anthropic_ai_sdk::types::message::{
 #[cfg(feature = "gem")]
 use gems::{
     chat::ChatBuilder,
+    imagen::ImageGenBuilder,
     messages::{Content, Message},
+    models::Model,
+    stream::StreamBuilder,
     traits::CTrait,
 };
+
+#[cfg(any(feature = "oai", feature = "gem", feature = "cld", feature = "xai"))]
+use crate::traits::functions::ReqResponse;
 
 #[cfg(feature = "xai")]
 use x_ai::{
@@ -241,7 +247,8 @@ impl BackendGPT {
             _ => panic!("Unsupported language '{language}'. Consider opening an issue/PR.",),
         }
 
-        let agent: AgentGPT = AgentGPT::new_borrowed(objective, position);
+        let mut agent: AgentGPT = AgentGPT::new_borrowed(objective, position);
+        agent.id = agent.position().to_string().into();
 
         let client = ClientType::from_env();
 

--- a/autogpt/src/agents/frontend.rs
+++ b/autogpt/src/agents/frontend.rs
@@ -86,9 +86,15 @@ use anthropic_ai_sdk::types::message::{
 #[cfg(feature = "gem")]
 use gems::{
     chat::ChatBuilder,
+    imagen::ImageGenBuilder,
     messages::{Content, Message},
+    models::Model,
+    stream::StreamBuilder,
     traits::CTrait,
 };
+
+#[cfg(any(feature = "oai", feature = "gem", feature = "cld", feature = "xai"))]
+use crate::traits::functions::ReqResponse;
 
 use async_trait::async_trait;
 #[cfg(feature = "xai")]
@@ -213,7 +219,8 @@ impl FrontendGPT {
             _ => panic!("Unsupported language, consider open an Issue/PR"),
         };
         #[allow(unused)]
-        let agent: AgentGPT = AgentGPT::new_borrowed(objective, position);
+        let mut agent: AgentGPT = AgentGPT::new_borrowed(objective, position);
+        agent.id = agent.position().to_string().into();
 
         #[allow(unused)]
         let client = ClientType::from_env();

--- a/autogpt/src/agents/git.rs
+++ b/autogpt/src/agents/git.rs
@@ -32,9 +32,15 @@ use {openai_dive::v1::models::FlagshipModel, openai_dive::v1::resources::chat::*
 #[cfg(feature = "gem")]
 use gems::{
     chat::ChatBuilder,
+    imagen::ImageGenBuilder,
     messages::{Content, Message},
+    models::Model,
+    stream::StreamBuilder,
     traits::CTrait,
 };
+
+#[cfg(any(feature = "oai", feature = "gem", feature = "cld", feature = "xai"))]
+use crate::traits::functions::ReqResponse;
 
 #[cfg(feature = "xai")]
 use x_ai::{
@@ -147,7 +153,8 @@ impl GitGPT {
             debug!("Workspace directory '{}' already exists.", workspace);
         }
 
-        let agent = AgentGPT::new_borrowed(objective, position);
+        let mut agent = AgentGPT::new_borrowed(objective, position);
+        agent.id = agent.position().to_string().into();
 
         let repo = if fs::try_exists(format!("{}/.git", &workspace))
             .await

--- a/autogpt/src/agents/mailer.rs
+++ b/autogpt/src/agents/mailer.rs
@@ -37,6 +37,9 @@ use gems::{
     traits::CTrait,
 };
 
+#[cfg(any(feature = "oai", feature = "gem", feature = "cld", feature = "xai"))]
+use crate::traits::functions::ReqResponse;
+
 #[cfg(feature = "xai")]
 use x_ai::{
     chat_compl::{ChatCompletionsRequestBuilder, Message as XaiMessage},
@@ -74,7 +77,8 @@ impl MailerGPT {
     /// - Creates a Gemini client for interacting with Gemini API.
     ///
     pub async fn new(objective: &'static str, position: &'static str) -> Self {
-        let agent: AgentGPT = AgentGPT::new_borrowed(objective, position);
+        let mut agent: AgentGPT = AgentGPT::new_borrowed(objective, position);
+        agent.id = agent.position().to_string().into();
         let client_id = var("NYLAS_CLIENT_ID").unwrap_or_default().to_owned();
         let client_secret = var("NYLAS_CLIENT_SECRET").unwrap_or_default().to_owned();
         let access_token = var("NYLAS_ACCESS_TOKEN").unwrap_or_default().to_owned();
@@ -594,5 +598,15 @@ impl AsyncFunctions for MailerGPT {
     #[cfg(feature = "mem")]
     async fn ltm_context(&self) -> String {
         long_term_memory_context(self.agent.id.clone()).await
+    }
+    #[cfg(any(feature = "oai", feature = "gem", feature = "cld", feature = "xai"))]
+    async fn imagen(&mut self, _request: &str) -> Result<Vec<u8>> {
+        // TODO: Impl
+        Ok(Default::default())
+    }
+    #[cfg(any(feature = "oai", feature = "gem", feature = "cld", feature = "xai"))]
+    async fn stream(&mut self, _request: &str) -> Result<ReqResponse> {
+        // TODO: Impl
+        Ok(ReqResponse(None))
     }
 }

--- a/autogpt/src/agents/manager.rs
+++ b/autogpt/src/agents/manager.rs
@@ -42,9 +42,15 @@ use anthropic_ai_sdk::types::message::{
 #[cfg(feature = "gem")]
 use gems::{
     chat::ChatBuilder,
+    imagen::ImageGenBuilder,
     messages::{Content, Message},
+    models::Model,
+    stream::StreamBuilder,
     traits::CTrait,
 };
+
+#[cfg(any(feature = "oai", feature = "gem", feature = "cld", feature = "xai"))]
+use crate::traits::functions::ReqResponse;
 
 #[cfg(feature = "xai")]
 use x_ai::{
@@ -95,7 +101,8 @@ impl ManagerGPT {
         request: &str,
         language: &'static str,
     ) -> Self {
-        let agent = AgentGPT::new_borrowed(objective, position);
+        let mut agent = AgentGPT::new_borrowed(objective, position);
+        agent.id = agent.position().to_string().into();
 
         let agents: Vec<AgentType> = Vec::new();
 

--- a/autogpt/src/agents/optimizer.rs
+++ b/autogpt/src/agents/optimizer.rs
@@ -102,9 +102,15 @@ use anthropic_ai_sdk::types::message::{
 #[cfg(feature = "gem")]
 use gems::{
     chat::ChatBuilder,
+    imagen::ImageGenBuilder,
     messages::{Content, Message},
+    models::Model,
+    stream::StreamBuilder,
     traits::CTrait,
 };
+
+#[cfg(any(feature = "oai", feature = "gem", feature = "cld", feature = "xai"))]
+use crate::traits::functions::ReqResponse;
 
 #[cfg(feature = "xai")]
 use x_ai::{
@@ -172,7 +178,8 @@ impl OptimizerGPT {
             debug!("Workspace directory '{}' already exists.", workspace);
         }
 
-        let agent = AgentGPT::new_borrowed(objective, position);
+        let mut agent = AgentGPT::new_borrowed(objective, position);
+        agent.id = agent.position().to_string().into();
 
         let client = ClientType::from_env();
 

--- a/autogpt/src/common/memory.rs
+++ b/autogpt/src/common/memory.rs
@@ -5,7 +5,7 @@ use pinecone_sdk::models::{Kind, Value, Vector};
 use pinecone_sdk::pinecone::PineconeClientConfig;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
-use tracing::error;
+use tracing::{error, warn};
 
 async fn embed_text(client: &mut ClientType, content: Cow<'static, str>) -> Vec<f64> {
     match client {
@@ -154,7 +154,7 @@ pub async fn save_long_term_memory(
         }),
     };
     if let Err(_e) = index.upsert(&[vector], &namespace.into()).await {
-        tracing::warn!("Failed to upsert vector");
+        warn!("Upsert failed -> check `PINECONE_INDEX_URL` and trial limits.");
     }
     Ok(())
 }

--- a/autogpt/src/traits/functions.rs
+++ b/autogpt/src/traits/functions.rs
@@ -10,6 +10,7 @@
 //! use anyhow::Result;
 //! use autogpt::traits::functions::Functions;
 //! use autogpt::traits::functions::AsyncFunctions;
+//! use autogpt::traits::functions::ReqResponse;
 //! use autogpt::common::utils::Communication;
 //! use autogpt::prelude::async_trait;
 //! use std::borrow::Cow;
@@ -123,6 +124,16 @@
 //!     async fn send_request(&mut self, _request: &str) -> Result<String> {
 //!         Ok("".to_string())
 //!     }
+//!
+//!     async fn imagen(&mut self, _request: &str) -> Result<Vec<u8>> {
+//!         // TODO: Impl
+//!         Ok(Default::default())
+//!     }
+//!
+//!     async fn stream(&mut self, _request: &str) -> Result<ReqResponse> {
+//!         // TODO: Impl
+//!         Ok(ReqResponse(None))
+//!     }
 //! }
 //!
 
@@ -132,6 +143,10 @@ use crate::common::utils::Communication;
 use crate::common::utils::{AgentMessage, Task};
 use anyhow::Result;
 use async_trait::async_trait;
+use reqwest::Response;
+
+#[derive(Default)]
+pub struct ReqResponse(pub Option<Response>);
 
 /// Trait to retrieve an agent.
 pub trait Functions {
@@ -201,6 +216,14 @@ pub trait AsyncFunctions: Send + Sync {
     #[allow(async_fn_in_trait)]
     #[cfg(any(feature = "oai", feature = "gem", feature = "cld", feature = "xai"))]
     async fn send_request(&mut self, request: &str) -> Result<String>;
+
+    #[allow(async_fn_in_trait)]
+    #[cfg(any(feature = "oai", feature = "gem", feature = "cld", feature = "xai"))]
+    async fn imagen(&mut self, request: &str) -> Result<Vec<u8>>;
+
+    #[allow(async_fn_in_trait)]
+    #[cfg(any(feature = "oai", feature = "gem", feature = "cld", feature = "xai"))]
+    async fn stream(&mut self, request: &str) -> Result<ReqResponse>;
 }
 
 #[async_trait]

--- a/autogpt/tests/designer.rs
+++ b/autogpt/tests/designer.rs
@@ -10,7 +10,6 @@ use autogpt::traits::functions::Functions;
 use tracing_subscriber::{filter, fmt, prelude::*, reload};
 
 #[tokio::test]
-#[ignore]
 #[cfg(feature = "img")]
 async fn test_generate_image_from_text() -> Result<()> {
     let filter = filter::LevelFilter::INFO;
@@ -43,7 +42,6 @@ async fn test_generate_image_from_text() -> Result<()> {
 }
 
 #[tokio::test]
-#[ignore]
 #[cfg(feature = "img")]
 async fn test_execute_agent() -> Result<()> {
     let objective = "Crafts stunning web design layouts";

--- a/autogpt/tests/functions.rs
+++ b/autogpt/tests/functions.rs
@@ -6,6 +6,7 @@ use autogpt::common::utils::{Route, Scope, Task};
 use autogpt::traits::agent::Agent;
 use autogpt::traits::functions::AsyncFunctions;
 use autogpt::traits::functions::Functions;
+use autogpt::traits::functions::ReqResponse;
 use serde_json::json;
 use std::borrow::Cow;
 use tracing::info;
@@ -81,6 +82,15 @@ impl AsyncFunctions for MockFunctions {
 
     async fn send_request(&mut self, _request: &str) -> Result<String> {
         Ok("".to_string())
+    }
+
+    async fn imagen(&mut self, _request: &str) -> Result<Vec<u8>> {
+        // TODO: Impl
+        Ok(Default::default())
+    }
+    async fn stream(&mut self, _request: &str) -> Result<ReqResponse> {
+        // TODO: Impl
+        Ok(ReqResponse(None))
     }
 }
 


### PR DESCRIPTION
- Added AutoGPT fields for execute, browse, max_tries, and scope permissions.
- Made Task scope configurable instead of hardcoded.
- Added trait methods for image generation and streaming responses.
- Enabled imagen usage for Gemini AI provider in designer.
- Fixed long term memory fetch when restarting the agent using the same id.

- [X] I have tested these changes locally.

https://github.com/user-attachments/assets/f4e4e13a-bce4-4427-b104-712afdbe9cff

One namespace for the same agent for mem fetching when restarting the cli:

<img width="452" height="279" alt="namespace" src="https://github.com/user-attachments/assets/a6127109-7b6e-402a-aa40-f0f99f8a5b0c" />

Gemini is a pretty good designer, ngl:

<img width="1024" height="638" alt="img" src="https://github.com/user-attachments/assets/12866ae7-3caa-492a-886c-16e7da0bfb99" />

 